### PR TITLE
Expose container-image-scan retry count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 -  `container_tag`: The container tag to scan against (default: `latest`)
 -  `crowdstrike_region`: The CrowdStrike Cloud region to submit for scanning (default: `us-1`)
 -  `crowdstrike_score`: The score threshold used to allow for step success (optional, default: `500`)
+-  `retry_count`: How many attempts will be made to download the scan report before giving up (optional, default: `10`)
 
 NOTE: Scoring is based on the CrowdStrike vulnerability severity tabe scoring shown below.
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   crowdstrike_score:
     description: "Vulnerability score threshold"
     default: 500
+  retry_count:
+    description: "Scan report download retries"
+    default: 10
 outputs:
   exit-code:
     description: "exit code of scan"
@@ -31,5 +34,5 @@ runs:
     - run: "pip install docker"
       shell: bash
     - id: scan-image
-      run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}'
+      run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}'
       shell: bash

--- a/scan.sh
+++ b/scan.sh
@@ -52,6 +52,12 @@ parse_args() {
             shift
         fi
         ;;
+      -R|--retry_count)
+        if [[ -n ${2:-} ]]; then
+            opts="$opts $1 $2"
+            shift
+        fi
+        ;;
       --) # end argument parsing
         shift
         break


### PR DESCRIPTION
https://github.com/CrowdStrike/container-image-scan/blob/main/cs_scanimage.py#L323 is now configurable. This pull request exposes retry_count to this action.