### PR TITLE
Exposes additional args --log-level && --json-report to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 -  `crowdstrike_region`: The CrowdStrike Cloud region to submit for scanning (default: `us-1`)
 -  `crowdstrike_score`: The score threshold used to allow for step success (optional, default: `500`)
 -  `retry_count`: How many attempts will be made to download the scan report before giving up (optional, default: `10`)
+-  `json_report`: Path to output the json report (optional, default: `None`)
+-  `log_level`: Set the logging level (optional, default: `INFO`)
 
 NOTE: Scoring is based on the CrowdStrike vulnerability severity tabe scoring shown below.
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
   retry_count:
     description: "Scan report download retries"
     default: 10
+  log_level:
+    description: "Set the logging level (default: INFO)"
+    default: INFO
+  json_report:
+    description: "Export JSON report to specified file (Default: None)"
 outputs:
   exit-code:
     description: "exit code of scan"
@@ -34,5 +39,5 @@ runs:
     - run: "pip install docker"
       shell: bash
     - id: scan-image
-      run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}'
+      run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}' --log-level '${{ inputs.log_level }}' --json-report '${{ inputs.json_report }}'
       shell: bash

--- a/scan.sh
+++ b/scan.sh
@@ -58,6 +58,18 @@ parse_args() {
             shift
         fi
         ;;
+      --log-level)
+        if [[ -n ${2:-} ]]; then
+            opts="$opts $1 $2"
+            shift
+        fi
+        ;;
+      --json-report)
+        if [[ -n ${2:-} ]]; then
+            opts="$opts $1 $2"
+            shift
+        fi
+        ;;
       --) # end argument parsing
         shift
         break


### PR DESCRIPTION
This change allows users to set inputs for log_level and json_report path args in their actions workflow files.