### PR TITLE
Add crowdstrike-falconpy dependency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: "pip install docker"
+    - run: "pip install docker crowdstrike-falconpy"
       shell: bash
     - id: scan-image
       run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}' --log-level '${{ inputs.log_level }}' --json-report '${{ inputs.json_report }}'


### PR DESCRIPTION
Adds the [crowdstrike-falconpy](https://github.com/CrowdStrike/falconpy) library as a new dependency introduced in version 0.0.9.