### PR TITLE
Deprecation/set output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: CrowdStrike Container Image Scan
-        uses: crowdstrike/container-image-scan-action@v0.8
+        uses: crowdstrike/container-image-scan-action@v0.9
         with:
           falcon_client_id: <my_falcon_client_id>
           container_repository: docker.io/library/busybox

--- a/scan.sh
+++ b/scan.sh
@@ -99,12 +99,12 @@ main() {
 
         python3 cs_scanimage.py --user-agent github-image-scan $opts
         EXIT_CODE=$?
-        echo "::set-output name=exit-code::$EXIT_CODE"
+        echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
         exit $EXIT_CODE
     else
         python3 cs_scanimage.py --user-agent github-image-scan
         EXIT_CODE=$?
-        echo "::set-output name=exit-code::$EXIT_CODE"
+        echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
         exit $EXIT_CODE
     fi
 }


### PR DESCRIPTION
Github is deprecating the use of ::set-output, this PR updates to use new GITHUB_OUTPUT environment files.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Includes a version bump assuming this will be merged and new release pushed.
