### PR TITLE
pass --break-system-packages to pip

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: "pip install -r https://raw.githubusercontent.com/CrowdStrike/container-image-scan/main/requirements.txt"
+    - run: "pip install --break-system-packages -r https://raw.githubusercontent.com/CrowdStrike/container-image-scan/main/requirements.txt"
       shell: bash
     - id: scan-image
       run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}' --log-level '${{ inputs.log_level }}' --json-report '${{ inputs.json_report }}'


### PR DESCRIPTION
As of around Oct 10 2024, this scan action stopped working with github's `ubuntu-latest` worker with error:

```
Run pip install -r https://raw.githubusercontent.com/CrowdStrike/container-image-scan/main/requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

This PR adds `--break-system-packages` to the `pip install` command to get it working again.

Since github workers are ephemeral, this should be OK to add (but if not, the alternative would be to refactor using virtual envs).

Reference: https://discourse.ubuntu.com/t/psa-for-folks-using-python-in-github-action-runners-and-ubuntu-latest-label/48654