### PR TITLE
Use `PIP_BREAK_SYSTEM_PACKAGES` environment variable instead of `--break-system-packages`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: "pip install --break-system-packages -r https://raw.githubusercontent.com/CrowdStrike/container-image-scan/main/requirements.txt"
+    - run: "PIP_BREAK_SYSTEM_PACKAGES=1 pip install -r https://raw.githubusercontent.com/CrowdStrike/container-image-scan/main/requirements.txt"
       shell: bash
     - id: scan-image
       run: $GITHUB_ACTION_PATH/scan.sh -u '${{ inputs.falcon_client_id }}' -r '${{ inputs.container_repository }}' -t '${{ inputs.container_tag }}' -c '${{ inputs.crowdstrike_region }}' -s '${{ inputs.crowdstrike_score }}' -R '${{ inputs.retry_count }}' --log-level '${{ inputs.log_level }}' --json-report '${{ inputs.json_report }}'


### PR DESCRIPTION
Our GitHub Action stopped working, likely because the GitHub runners on my account are not running a version of pip that supports the `--break-system-packages` option. This results in the following error: 
>no such option: --break-system-packages.

To resolve this, instead of relying on the `--break-system-packages` option (which might not be available), I've updated the action to use the environment variable `PIP_BREAK_SYSTEM_PACKAGES=1`, which should achieve the same effect.

One thing I’m still trying to figure out is that my action was running on v1, and while I’m not entirely sure, it seems this version was working before but now points to one where it doesn’t. If possible, could you please keep an eye on backward compatibility moving forward? 🙏

Note: I haven’t tested this and I’m not sure how to. Please keep me honest as you review this PR 🙏